### PR TITLE
Task.7-1 記事に関するAPIのルーティングの実装【Article に関する API 実装】の完了。

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,11 @@
 Rails.application.routes.draw do
-  mount_devise_token_auth_for 'User', at: 'auth'
+
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+  namespace :api do
+    namespace :v1 do
+      mount_devise_token_auth_for 'User', at: 'auth'
+      resources :articles
+      # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+    end
+  end
 end


### PR DESCRIPTION
## Task.7-1 記事に関するAPIのルーティングの実装【Article に関する API 実装】の完了。
- mount_devise_token_auth_for 'User', at: 'auth'の記述位置だけ少し異なっていた。