### PR TITLE
Task. 11-3 下書き記事の一覧/詳細 のAPI実装【下書き機能の実装】のコントローラーの実装の完了。

### DIFF
--- a/app/controllers/api/v1/articles/drafts_controller.rb
+++ b/app/controllers/api/v1/articles/drafts_controller.rb
@@ -1,0 +1,13 @@
+class Api::V1::Articles::DraftsController < ApplicationController
+  def index
+    articles = Article.draft.order(updated_at: :desc)
+    render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
+  end
+
+  def show
+    article = Article.draft.find(params[:id])
+    render json: article, serializer: Api::V1::ArticleSerializer
+  end
+
+
+end

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -3,45 +3,35 @@ module Api::V1
     before_action :authenticate_user!, only: [:create, :update, :destroy]
 
     def index
-      articles = Article.order(updated_at: :desc)
+      articles = Article.published.order(updated_at: :desc)
       render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
     end
 
     def show
-      #binding.pry
-      article = Article.find(params[:id])
+      article = Article.published.find(params[:id])
       render json: article, serializer: Api::V1::ArticleSerializer
     end
 
     def create
-      # binding.pry
       article = current_user.articles.create!(article_params)
       render json: article, serializer: Api::V1::ArticleSerializer
-
     end
 
     def update
-        article = current_user.articles.find(params[:id])
-        article.update!(article_params)
-        render json: article, serializer: Api::V1::ArticleSerializer
+      article = current_user.articles.find(params[:id])
+      article.update!(article_params)
+      render json: article, serializer: Api::V1::ArticleSerializer
     end
 
     def destroy
-        # 対象のレコードを探す
-        # binding.pry
-        article = current_user.articles.find(params[:id])
-        # 探してきたレコードを削除する
-        article.destroy!
-        # json として値を返す
-        render json: article, serializer: Api::V1::ArticleSerializer
+      article = current_user.articles.find(params[:id])
+      article.destroy!
     end
-
 
     private
 
-    def article_params
-      params.require(:article).permit(:title, :body)
-    end
-
+      def article_params
+        params.require(:article).permit(:title, :body, :status)
+      end
   end
 end

--- a/app/serializers/api/v1/article_serializer.rb
+++ b/app/serializers/api/v1/article_serializer.rb
@@ -1,4 +1,4 @@
 class Api::V1::ArticleSerializer < ActiveModel::Serializer
-  attributes :id, :title, :body, :updated_at
+  attributes :id, :title, :body, :status, :updated_at
   belongs_to :user, serializer: Api::V1::UserSerializer
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,10 +9,16 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
+      namespace :articles do
+        resources :drafts
+      end
       mount_devise_token_auth_for "User", at: "auth", controllers: {
         registrations: "api/v1/auth/registrations",
       }
       resources :articles
+
+
+
     end
   end
 end

--- a/spec/requests/api/v1/articles/drafts_spec.rb
+++ b/spec/requests/api/v1/articles/drafts_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::Articles::Drafts", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/spec/requests/articles_spec.rb
+++ b/spec/requests/articles_spec.rb
@@ -1,99 +1,159 @@
-require 'rails_helper'
+require "rails_helper"
 
-RSpec.describe "articles", type: :request do
-  describe "GET /api_v1_articles" do
-    # binding.pry
+RSpec.describe "Api::V1::Articles", type: :request do
+  describe "GET /articles" do
     subject { get(api_v1_articles_path) }
-    before { create_list(:article, 3) }
-    it "記事の一覧が取得できる" do
+
+    let!(:article1) { create(:article, :published, updated_at: 1.days.ago) }
+    let!(:article2) { create(:article, :published, updated_at: 2.days.ago) }
+    let!(:article3) { create(:article, :published) }
+
+    before { create(:article, :draft) }
+
+    it "公開済みの記事の一覧が取得できる(更新順)" do
       subject
       res = JSON.parse(response.body)
+
+      expect(response).to have_http_status(:ok)
       expect(res.length).to eq 3
-      expect(res[0].keys).to eq ["id", "title"]
-      expect(response).to have_http_status(200)
+      expect(res.map {|d| d["id"] }).to eq [article3.id, article1.id, article2.id]
+      expect(res[0].keys).to eq ["id", "title", "updated_at", "user"]
+      expect(res[0]["user"].keys).to eq ["id", "name", "email"]
     end
   end
 
-  describe "GET /api_v1_articles/:id" do
-    # 中略
-
+  describe "GET /articles/:id" do
     subject { get(api_v1_article_path(article_id)) }
 
-    context "指定した id の記事が存在するとき" do
-      let(:article) { create(:article) }
+    context "指定した id の記事が存在して" do
       let(:article_id) { article.id }
-      it "その記事のレコードが取得できる" do
-        subject
-        res = JSON.parse(response.body)
-        expect(response).to have_http_status(200)
-        expect(res["title"]).to eq article.title
-        expect(res["body"]).to eq article.body
+
+      context "対象の記事が公開中であるとき" do
+        let(:article) { create(:article, :published) }
+
+        it "任意の記事が取得できる" do
+          subject
+          res = JSON.parse(response.body)
+
+          expect(response).to have_http_status(:ok)
+          expect(res["id"]).to eq article.id
+          expect(res["title"]).to eq article.title
+          expect(res["body"]).to eq article.body
+          expect(res["updated_at"]).to be_present
+          expect(res["user"]["id"]).to eq article.user.id
+          expect(res["user"].keys).to eq ["id", "name", "email"]
+        end
+      end
+
+      context "対象の記事が下書き状態であるとき" do
+        let(:article) { create(:article, :draft) }
+
+        it "記事が見つからない" do
+          expect { subject }.to raise_error ActiveRecord::RecordNotFound
+        end
       end
     end
 
-    context "指定した id の記事が存在しないとき" do
+    context "指定した id の記事が存在しない場合" do
       let(:article_id) { 10000 }
+
       it "記事が見つからない" do
         expect { subject }.to raise_error ActiveRecord::RecordNotFound
       end
     end
   end
 
-
   describe "POST /articles" do
     subject { post(api_v1_articles_path, params: params, headers: headers) }
 
-    let(:params) { { article: attributes_for(:article) } }
-    let(:current_user) { create(:user) }
-
-    # stub
-    let(:headers) { current_user.create_new_auth_token }
-
-    it "記事のレコードが作成できる" do
-      expect { subject }.to change { Article.where(user_id: current_user.id).count }.by(1)
-      res = JSON.parse(response.body)
-      expect(res["title"]).to eq params[:article][:title]
-      expect(res["body"]).to eq params[:article][:body]
-      expect(response).to have_http_status(:ok)
-    end
-  end
-  describe "PATCH /api/v1/articles/:id" do
-    subject { patch(api_v1_article_path(article.id), params: params, headers: headers) }
-
-    let(:params) { { article: attributes_for(:article) } }
     let(:current_user) { create(:user) }
     let(:headers) { current_user.create_new_auth_token }
 
-    context "自分が所持している記事のレコードを更新しようとするとき" do
-      let(:article) { create(:article, user: current_user) }
+    context "公開指定で記事を作成するとき" do
+      let(:params) { { article: attributes_for(:article, :published) } }
 
-      it "記事を更新できる" do
-        expect { subject }.to change { article.reload.title }.from(article.title).to(params[:article][:title]) &
-                              change { article.reload.body }.from(article.body).to(params[:article][:body])
+      it "記事のレコードが作成できる" do
+        expect { subject }.to change { Article.where(user_id: current_user.id).count }.by(1)
+        res = JSON.parse(response.body)
+        expect(res["title"]).to eq params[:article][:title]
+        expect(res["body"]).to eq params[:article][:body]
         expect(response).to have_http_status(:ok)
       end
     end
 
-    context "自分が所持していない記事のレコードを更新しようとするとき" do
+    context "下書き指定で記事を作成するとき" do
+      let(:params) { { article: attributes_for(:article, :draft) } }
+
+      it "下書き記事が作成できる" do
+        expect { subject }.to change { Article.count }.by(1)
+        res = JSON.parse(response.body)
+        expect(res["status"]).to eq "draft"
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "でたらめな指定で記事を作成するとき" do
+      let(:params) { { article: attributes_for(:article, status: :foo) } }
+
+      it "エラーになる" do
+        expect { subject }.to raise_error(ArgumentError)
+      end
+    end
+  end
+
+  describe "PATCH /api/v1/articles/:id" do
+    subject { patch(api_v1_article_path(article.id), params: params, headers: headers) }
+
+    let(:params) { { article: attributes_for(:article, :published) } }
+    let(:current_user) { create(:user) }
+    let(:headers) { current_user.create_new_auth_token }
+
+    context "自分の記事を更新するとき" do
+      let!(:article) { create(:article, :draft, user: current_user) }
+
+      it "任意の記事の更新ができる" do
+        expect { subject }.to change { article.reload.title }.from(article.title).to(params[:article][:title]) &
+                              change { article.reload.body }.from(article.body).to(params[:article][:body]) &
+                              change { article.reload.status }.from(article.status).to(params[:article][:status].to_s)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "他のユーザーの記事を更新しようとるすとき" do
       let(:other_user) { create(:user) }
       let!(:article) { create(:article, user: other_user) }
 
       it "更新できない" do
         expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
+        change { Article.count }.by(0)
       end
     end
   end
 
-  describe "DELETE /api/v1/articles/:id" do
-    # binding.pry
+  describe "DELETE /articles/:id" do
     subject { delete(api_v1_article_path(article_id), headers: headers) }
-    let(:article) { create(:article) }
-    let!(:article_id) { article.id }
+
     let(:current_user) { create(:user) }
+    let(:article_id) { article.id }
     let(:headers) { current_user.create_new_auth_token }
 
-    it "任意のユーザーのレコードを削除できる" do
-      expect { subject }.to change { Article.count }.by(-1)
+    context "自分の記事を削除しようとするとき" do
+      let!(:article) { create(:article, user: current_user) }
+
+      it "記事を削除できる" do
+        expect { subject }.to change { Article.count }.by(-1)
+        expect(response).to have_http_status(:no_content)
+      end
+    end
+
+    context "他人が所持している記事のレコードを削除しようとするとき" do
+      let(:other_user) { create(:user) }
+      let!(:article) { create(:article, user: other_user) }
+
+      it "記事を削除できない" do
+        expect { subject }.to raise_error(ActiveRecord::RecordNotFound) &
+                              change { Article.count }.by(0)
+      end
     end
   end
 end


### PR DESCRIPTION
## Task. 11-3 下書き記事の一覧/詳細 のAPI実装【下書き機能の実装】のコントローラーの実装の完了。
- 下書き記事のコントローラーの実装まで完了。
- ルーティングが競合した場合は上部に書かれているものが優先されると知ることができた。
- コントローラーの実装は調べながらの実装ができている。